### PR TITLE
Script to convert from python 2 to 3 in all notebooks

### DIFF
--- a/code/init_mooc_nb.py
+++ b/code/init_mooc_nb.py
@@ -7,7 +7,7 @@ except NameError:
 import sys
 import os
 
-module_dir = os.path.dirname(__file__)
+module_dir = os.path.dirname("__file__")
 sys.path.extend(module_dir)
 
 import re

--- a/scripts/ipython3-versioncontrol/LICENSE.md
+++ b/scripts/ipython3-versioncontrol/LICENSE.md
@@ -1,0 +1,19 @@
+The MIT License
+
+Copyright (c) 2015 Balabit SA
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions: The above copyright notice and this
+permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/scripts/ipython3-versioncontrol/README.md
+++ b/scripts/ipython3-versioncontrol/README.md
@@ -1,0 +1,37 @@
+##Short description of the Ipython 3 to/from Python converter files.
+
+The *ipython notebook --script* run option that produced python codes
+from an Ipython 2 notebook is deprecated in Ipython 3 (Jupyter, nbformat 4).
+The python file that Jupyter can produce has several shortcomings, the most
+problematic one is the missing metainformation: there is no cell type
+metadata, just a bracket indicates where a new code cell starts, but information
+about markdowncells are completly lost. This is why restoring the
+notebook (without the output content) without losing important
+information is not possible right now.
+
+
+The scripts in the folder suggest a solution to this problem.
+
++ *notebook_v4_to_py.py* converts an Ipython notebook to py file that preserves
+cell metadata. The conversion can be done manually by running the following
+command
+
+python notebook_v4_to_py.py -f notebook_filename.ipynb
+
++ While this script works, it is much more convenient to make Jupyter create
+the python file itself automatically. This can be done by adding the content
+of *ipython_notebook_config.txt* to the ipython_notebook_config.py in the config
+file which can be located with
+
+ipython locate profile default
+
++ The python files then can be version controlled, and the converter script that
+creates a notebook feom the .py file is *py_to_notebook_v4.py*:
+
+python py_to_notebook_v4.py -f py_filename.py
+
+Call the scripts with argument "--overwrite" to overwrite existing .ipynb or
+.py files.
+
+Call the scripts with argument "--dry-run" to simulate (print out) what would
+happen.

--- a/scripts/ipython3-versioncontrol/ipython_notebook_config.txt
+++ b/scripts/ipython3-versioncontrol/ipython_notebook_config.txt
@@ -1,0 +1,101 @@
+#Check the location on your IPython notebook profile:
+#    ipython locate profile default
+#
+#If you do not have any, create a new one:
+#    ipython profile create
+#
+#In your profile directory, you can find a file named ipython_notebook_config.py.
+#You can add extra functionalities to your IPython notebook there.
+#
+#We add the functionality of creating a .py file next to the .ipynb file each time
+#the notebook is saved. This is also called a post-hook method.
+#We based our solution on this snippet, which also converts the notebook to a
+#Python script file but with less metadata.
+#
+# Auto-convert ipython notebooks to a readable and version-controllable python script file
+# This was useful: https://gist.github.com/masnick/d89c03ba3f0ad48416a5
+#
+################################################################################
+
+#===============================================================================
+#This script is released under the MIT License
+#
+#Copyright (c) 2015 Balabit SA
+#
+#Permission is hereby granted, free of charge, to any person obtaining a copy of
+#this software and associated documentation files (the "Software"), to deal in
+#the Software without restriction, including without limitation the rights to use,
+#copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+#Software, and to permit persons to whom the Software is furnished to do so,
+#subject to the following conditions:
+#
+#The above copyright notice and this permission notice shall be included in all
+#copies or substantial portions of the Software.
+#
+#THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+#INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+#PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+#ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+#WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#===============================================================================
+#
+#In ipython_notebook_config.py, we insert the following Python code:
+
+import sys
+import json
+import os
+
+reload(sys)
+sys.setdefaultencoding('utf8')
+
+def get_notebook_data(path_to_file):
+    with open(path_to_file, 'r') as notebook:
+        notebook_data = json.load(notebook)
+    return notebook_data
+
+def construct_output_py_file_path(input_file_path, skip_if_exists=True):
+    input_headless, ext = os.path.splitext(input_file_path)
+    assert ext=='.ipynb'
+    output_by_path = input_headless + '.py'
+    if os.path.exists(output_by_path) and skip_if_exists:
+        return
+    return output_by_path
+
+def write_notebook_data_to_py(notebook_data, out_file_path):
+    with open(out_file_path, 'w') as output:
+        output.write('# -*- coding: utf-8 -*-\n')
+        output.write('# <nbformat>' + str(notebook_data['nbformat']) + '</nbformat>\n')
+        try:
+            cells = notebook_data['cells']
+        except KeyError:
+            print "Nbformat is " + str(notebook_data['nbformat']) + ", try the old converter script."
+            return
+
+        for cell in cells:
+            if cell['cell_type'] in ['code', 'markdown']:
+                output.write('\n')
+                output.write('# <' + cell['cell_type'] + 'cell' + '>\n')
+                output.write('\n')
+                for item in cell['source']:
+                    if cell['cell_type']=='code':
+                        output.write(item)
+                    else:
+                        output.write('# ')
+                        output.write(item)
+                output.write('\n')
+
+def post_save(model, os_path, contents_manager):
+    """post-save hook for converting notebooks to .py scripts"""
+    if model['type'] != 'notebook':
+        return # only do this for notebooks
+    if 'Untitled' in os_path:
+        return # do not save untitled notebooks
+
+    output_file_path = construct_output_py_file_path(os_path, skip_if_exists=False)
+    notebook_data = get_notebook_data(os_path)
+    write_notebook_data_to_py(notebook_data, output_file_path)
+    print output_file_path, "was successfully saved"
+
+c = get_config()
+c.FileContentsManager.post_save_hook = post_save

--- a/scripts/ipython3-versioncontrol/notebook_v4_to_py.py
+++ b/scripts/ipython3-versioncontrol/notebook_v4_to_py.py
@@ -1,0 +1,119 @@
+"""
+   The script takes an .ipynb file (or all such files in the directory), and,
+   if it doesn't already have a corresponding .py file, creates it from the
+   .ipynb file. We do this because we don't want to version-control .ipynb files
+   (which can contain images, matrices, data frames, etc), but we do want to
+   save the content of the notebook cells.
+
+   This is intented to be a replacement of the deprecated
+
+   ipython notebook --script
+
+   command for Ipython 2 notebooks that automatically saved notebooks as .py
+   files that can be version controled.
+
+   Optionally, the first three functions can be used for post-hook autosave in
+   the ipython_notebook_config.py file.
+
+   Call this script with argument "-f" to create a .py file from  notebook:
+
+   python notebook_v4_to_py.py -f filename.ipynb
+
+   Call the script with argument "--overwrite" to overwrite existing .py files.
+
+   Date: 07. August 2015.
+   #############################################################################
+
+   This script is released under the MIT License
+
+   Copyright (c) 2015 Balabit SA
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy of
+   this software and associated documentation files (the "Software"), to deal in
+   the Software without restriction, including without limitation the rights to use,
+   copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+   Software, and to permit persons to whom the Software is furnished to do so,
+   subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+   PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import sys
+import json
+import os
+import fnmatch
+
+reload(sys)
+sys.setdefaultencoding('utf8')
+THIS_FILE = os.path.abspath(__file__)
+
+def get_notebook_data(path_to_file):
+    with open(path_to_file, 'r') as notebook:
+        notebook_data = json.load(notebook)
+    return notebook_data
+
+def construct_output_py_file_path(input_file_path, skip_if_exists=True):
+    input_headless, ext = os.path.splitext(input_file_path)
+    assert ext=='.ipynb'
+    output_by_path = input_headless + '.py'
+    if os.path.exists(output_by_path) and skip_if_exists:
+        return
+    return output_by_path
+
+def write_notebook_data_to_py(notebook_data, out_file_path):
+    with open(out_file_path, 'w') as output:
+        output.write('# -*- coding: utf-8 -*-\n')
+        output.write('# <nbformat>' + str(notebook_data['nbformat']) + '</nbformat>\n')
+        try:
+            cells = notebook_data['cells']
+        except KeyError:
+            print(("Nbformat is " + str(notebook_data['nbformat']) + ", try the old converter script."))
+            return
+
+        for cell in cells:
+            if cell['cell_type'] in ['code', 'markdown']:
+                output.write('\n')
+                output.write('# <' + cell['cell_type'] + 'cell' + '>\n')
+                output.write('\n')
+                for item in cell['source']:
+                    if cell['cell_type']=='code':
+                        output.write(item)
+                    else:
+                        output.write('# ')
+                        output.write(item)
+                output.write('\n')
+
+def convert_notebook_to_py(input_file_path, skip_if_exists=True):
+    output_file_path = construct_output_py_file_path(input_file_path, skip_if_exists)
+    if output_file_path is not None:
+        notebook_data = get_notebook_data(input_file_path)
+        write_notebook_data_to_py(notebook_data, output_file_path)
+
+def convert_all_notebook_to_py(directory, skip_if_exists=True):
+    for root, dirnames, filenames in os.walk(directory):
+        for filename in fnmatch.filter(filenames, '*.ipynb'):
+            filename = os.path.abspath(os.path.join(root, filename))
+            print(filename)
+            if filename != THIS_FILE:
+                convert_notebook_to_py(filename, skip_if_exists)
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-w', '--overwrite', action='store_true', help='Overwrite existing py files', default=False)
+    parser.add_argument('-f', '--file', help='Specify an Ipython notebook if you only want to convert one. '
+                                       '(This will overwrite default.)')
+    args = parser.parse_args()
+
+    if args.file is not None:
+        convert_notebook_to_py(args.file, skip_if_exists=not args.overwrite)
+    else:
+        convert_all_notebook_to_py(directory='.', skip_if_exists=not args.overwrite)

--- a/scripts/ipython3-versioncontrol/py_to_notebook_v4.py
+++ b/scripts/ipython3-versioncontrol/py_to_notebook_v4.py
@@ -1,0 +1,185 @@
+"""
+   This script converts a .py file to Ipython v4 notebook format. The .py file
+   must be a result of an Ipython -> .py conversion using the notebook_v4_to_py.py
+   script or the automatic post-hook save in Ipyhon 3 based on that script.
+   In this way the version controlled .py files can be converted back to Ipython
+   notebook format.
+
+   Call this script with argument "-f" to create an .ipynb file from a .py file:
+
+   python py_to_notebook_v4.py -f filename.py
+
+   Call the script with argument "--overwrite" to overwrite existing .ipynb files.
+
+   Call the script with argument "--dry-run" to simulate (print) what would happen.
+
+   Date: 07. August 2015.
+   #############################################################################
+
+   This script is released under the MIT License
+
+   Copyright (c) 2015 Balabit SA
+
+   Permission is hereby granted, free of charge, to any person obtaining a copy of
+   this software and associated documentation files (the "Software"), to deal in
+   the Software without restriction, including without limitation the rights to use,
+   copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the
+   Software, and to permit persons to whom the Software is furnished to do so,
+   subject to the following conditions:
+
+   The above copyright notice and this permission notice shall be included in all
+   copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+   INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+   PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+   ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+"""
+import sys
+import json
+import os
+import fnmatch
+
+reload(sys)
+sys.setdefaultencoding('utf8')
+THIS_FILE = os.path.abspath(__file__)
+
+def get_py_data(path_to_file):
+    with open(path_to_file, 'r') as pythonfile:
+        lines = pythonfile.readlines()
+    return lines
+
+def construct_output_ipynb_file_path(input_file_path, skip_if_exists=True):
+    input_headless, ext = os.path.splitext(input_file_path)
+    assert ext=='.py'
+    output_by_path = input_headless + '.ipynb'
+    if os.path.exists(output_by_path) and skip_if_exists:
+        return
+    return output_by_path
+
+def build_notebook_cells(lines):
+    def close_cell(current_cell):
+        if current_cell in ['markdown', 'code']:
+            if not last_cell and len(source) > 1:
+                del source[-1:]
+            source[-1] = source[-1].rstrip('\n')
+            cell['source'] = source
+            outputcells.append(cell)
+        return outputcells
+
+    def open_cell(line, execution_count):
+        if '<markdowncell>' in line:
+            cell = {'cell_type': 'markdown',
+                    'metadata': {}}
+            source = []
+            current_cell = 'markdown'
+        elif '<codecell>' in line:
+            cell = {'cell_type': 'code',
+                    'execution_count': execution_count,
+                    'metadata': {'collapsed': False},
+                    'outputs': []}
+            source = []
+            current_cell = 'code'
+        return cell, source, current_cell
+
+    current_cell = 'unknown'
+    execution_count = 1
+    skip_one_line = False
+    last_cell = False
+    outputcells = []
+
+    for line in lines:
+        if skip_one_line:
+            skip_one_line = False
+            continue
+
+        if line=='# <markdowncell>\n' or line=='# <codecell>\n':
+            outputcells = close_cell(current_cell)
+            if current_cell=='code':
+                execution_count += 1
+            cell, source, current_cell = open_cell(line, execution_count)
+            skip_one_line = True
+            continue
+
+        if current_cell=='markdown':
+            if len(line) > 1:
+                source.append(line[2:])
+            else:
+                source.append(line)
+        elif current_cell=='code':
+            source.append(line)
+
+    last_cell = True
+    outputcells = close_cell(current_cell)
+    return outputcells
+
+def create_initial_output(lines):
+    kernelspec = {'display_name': 'Python 2',
+                  'language': 'python',
+                  'name': 'python2'}
+    language_info = {'codemirror_mode': {'name': 'ipython', 'version': 2},
+                     'file_extension': '.py',
+                     'mimetype': 'text/x-python',
+                     'name': 'python',
+                     'nbconvert_exporter': 'python',
+                     'pygments_lexer': 'ipython2',
+                     'version': '2.7.10'}
+    metadata = {'kernelspec': kernelspec,
+                'language_info': language_info}
+    nbformat_minor = 0
+
+    if '<nbformat>' in lines[1]:
+        nbformat = lines[1].split('>')[1].split('<')[0]
+        try:
+            nbformat = int(nbformat)
+        except ValueError:
+            nbformat = float(nbformat)
+    else:
+        return
+
+    output = {'metadata': metadata,
+              'nbformat': nbformat,
+              'nbformat_minor': nbformat_minor}
+    return output
+
+def write_py_data_to_notebook(output, out_file_path):
+    with open(out_file_path, 'w') as outfile:
+        json.dump(output, outfile)
+
+def convert_py_to_notebook(input_file_path, skip_if_exists=True, dry_run=False):
+    output_file_path = construct_output_ipynb_file_path(input_file_path, skip_if_exists)
+    if output_file_path is not None:
+        py_data = get_py_data(input_file_path)
+        if len(py_data) > 1:
+            output = create_initial_output(py_data)
+            if output is not None:
+                outputcells = build_notebook_cells(py_data)
+                output['cells'] = outputcells
+                if not dry_run:
+                    write_py_data_to_notebook(output, output_file_path)
+                print(("Created Ipython Jupyter notebook file: {}".format(output_file_path)))
+
+def convert_all_py_to_notebook(directory, skip_if_exists=True, dry_run=False):
+    for root, dirnames, filenames in os.walk(directory):
+        for filename in fnmatch.filter(filenames, '*.py'):
+            filename = os.path.abspath(os.path.join(root, filename))
+            print(filename)
+            if filename != THIS_FILE:
+                convert_py_to_notebook(filename, skip_if_exists=skip_if_exists, dry_run=dry_run)
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('-w', '--overwrite', action='store_true', help='Overwrite existing py files', default=False)
+    parser.add_argument('-f', '--file', help='Specify an Ipython notebook if you only want to convert one. '
+                                       '(This will overwrite default.)')
+    parser.add_argument('--dry-run', action='store_true', help='Only prints what would happen', default=False)
+    args = parser.parse_args()
+
+    if args.file is not None:
+        convert_py_to_notebook(args.file, skip_if_exists=not args.overwrite, dry_run=args.dry_run)
+    else:
+        convert_all_py_to_notebook(directory='.', skip_if_exists=not args.overwrite, dry_run=args.dry_run)

--- a/scripts/nb_py2to3.sh
+++ b/scripts/nb_py2to3.sh
@@ -2,6 +2,8 @@ cd ..
 p="$PWD"
 script_path="$p/scripts/ipython3-versioncontrol"
 point_dash="./"; dash="/"
+old="%run ../code/init_mooc_nb.py"
+new="exec(compile(open('../code/init_mooc_nb.py', 'rb').read(), '../code/init_mooc_nb.py', 'exec'))"
 
 find ./* -type d | while read -r line;
 do
@@ -13,10 +15,8 @@ do
 			python $script_path/notebook_v4_to_py.py -f "$file";
 			py_file_path="${file//.ipynb/.py}"
 			data=$(<"$py_file_path")
-			echo "${data//%run/#%run}" > $py_file_path
+			echo "${data//$old/$new}" > $py_file_path
 			2to3 -w -n "$py_file_path";
-			data=$(<"$py_file_path")
-			echo "${data//#%run/%run}" > $py_file_path
 			python $script_path/py_to_notebook_v4.py -f "$py_file_path" --overwrite;
 			rm "$py_file_path";
 		fi;

--- a/scripts/nb_py2to3.sh
+++ b/scripts/nb_py2to3.sh
@@ -1,0 +1,24 @@
+cd ..
+p="$PWD"
+script_path="$p/scripts/ipython3-versioncontrol"
+point_dash="./"; dash="/"
+
+find ./* -type d | while read -r line;
+do
+        STR="$p$line";
+        cd "${STR//$point_dash/$dash}"
+	for file in *.ipynb;
+		do
+		if [ "$file" != "*.ipynb" ]; then
+			python $script_path/notebook_v4_to_py.py -f "$file";
+			py_file_path="${file//.ipynb/.py}"
+			data=$(<"$py_file_path")
+			echo "${data//%run/#%run}" > $py_file_path
+			2to3 -w -n "$py_file_path";
+			data=$(<"$py_file_path")
+			echo "${data//#%run/%run}" > $py_file_path
+			python $script_path/py_to_notebook_v4.py -f "$py_file_path" --overwrite;
+			rm "$py_file_path";
+		fi;
+		done;
+done;


### PR DESCRIPTION
Related to #90. This is a script that converts python code in all the notebooks from python 2 to 3.

I wanted to use 2to3 to convert from python 2 to 3. It does not work with notebooks directly however, so I had the idea to convert notebooks to python scripts, use 2to3 and then convert back to notebooks. Using nbconvert, it is possible to convert a notebook to a python script, but not vice versa. I did however come across this: https://github.com/balabit/ipython3-versioncontrol. This repo contains python scripts to convert v4 notebooks to py files, and vice versa.

It seems to me that it works quite well. However, if one converts a notebook from the course and then runs 2to3 directly, it throws an error. This is because of the way the conversion scripts write out ipython magic commands in the py file, and every course notebook includes a line starting with %run ... As a work around, the bash script comments all instances of %run in the py file before running 2to3, and then uncomments them before converting the py file back to a notebook.

I've tested it, and think it works. Please have a look. If you give me the green light, I'll make the conversion.

Note that the script only converts .ipynb files, not .py files.