### PR TITLE
Insert newline at end if missing

### DIFF
--- a/scripts/nb_filter_clean.sh
+++ b/scripts/nb_filter_clean.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 temp_out=$(mktemp)
 cat > $temp_out
+sed -i '' -e '$a\' $temp_out
 jupyter nbconvert --to notebook --config scripts/config_filter_clean.py $temp_out --stdout
 rm $temp_out

--- a/scripts/nb_filter_smudge.sh
+++ b/scripts/nb_filter_smudge.sh
@@ -5,5 +5,6 @@ mv $temp_out $temp_out.ipynb
 cat > $temp_out.ipynb
 jupyter nbconvert --to notebook --config scripts/config_filter_smudge.py $temp_out.ipynb --output $temp_out.ipynb 1>&2
 jupyter trust $temp_out.ipynb > /dev/null
+sed -i '' -e '$a\' $temp_out.ipynb
 cat $temp_out.ipynb
 rm $temp_out.ipynb


### PR DESCRIPTION
Carbon copy of http://unix.stackexchange.com/questions/31947/how-to-add-a-newline-to-the-end-of-a-file

I'm not sure if this actually fixes the issue, as this is presently not a problem in any notebook for me. However, with this modification, the filter still runs on my laptop, so presumably the sed command finds the temporary notebook.