### PR TITLE
corrected order of kdims in dislocation holomap

### DIFF
--- a/w7_defects/crystalline_defects.ipynb
+++ b/w7_defects/crystalline_defects.ipynb
@@ -259,7 +259,7 @@
     "                                 holoviews.Raster(density[0][:, :, n], label='{\\left|\\psi|}^2'))\n",
     "\n",
     "\n",
-    "    return holoviews.HoloMap(hm_dict, kdims=['model', 'n'])"
+    "    return holoviews.HoloMap(hm_dict, kdims=['n', 'model'])"
    ]
   },
   {


### PR DESCRIPTION
The "model" and "n" labels are swapped in the HoloMaps in the dislocations section. This confused me ("What's 'model', and why is it a number?") until I figured out that it's a simple mistake.