### PR TITLE
make sure the clean and smudge filters are run in py3k

### DIFF
--- a/scripts/nb_filter_clean.sh
+++ b/scripts/nb_filter_clean.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-jupyter nbconvert --to notebook --config scripts/config_filter_clean.py --stdin --stdout
+python3 -m nbconvert --to notebook --config scripts/config_filter_clean.py --stdin --stdout

--- a/scripts/nb_filter_smudge.sh
+++ b/scripts/nb_filter_smudge.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 export PYTHONPATH=$PYTHONPATH:${PWD}/code
-jupyter nbconvert --to notebook --config scripts/config_filter_smudge.py --stdin --stdout
+python3 -m nbconvert --to notebook --config scripts/config_filter_smudge.py --stdin --stdout


### PR DESCRIPTION
On my (linux) system, the `jupyter` script (for whatever reason) is run with `/usr/bin/python`, which is python 2.7. The filter scripts require python 3 and won't run. Running python3 explicitly fixes that problem.