### PR TITLE
turn warnings into errors

### DIFF
--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -51,8 +51,10 @@ cfg = Config({'NotebookExporter': {'preprocessors':
                                                          'code/edx_components.py',
                                                          'code/pfaffian.py',
                                                          'code/functions.py'],
+                                           'warnings_to_errors': True,
                                            'timeout': 300}})
 cachedoutput = NotebookExporter(cfg)
+
 
 with open('scripts/release_dates') as f:
     release_dates = eval(f.read())


### PR DESCRIPTION
Closes #169.

I ran the converter prior to adding this on hpc1 using python 3, and some output cells indeed contained errors. After adding these lines, the converter finds a warning and terminates. But from the traceback, I'm not sure if this is the behaviour we want - it seems to terminate due to a deprecated method in nbconvert.

```python
Traceback (most recent call last):
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/traitlets/traitlets.py", line 501, in get
    value = obj._trait_values[self.name]
KeyError: 'file_extension'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "scripts/converter.py", line 682, in <module>
    main()
  File "scripts/converter.py", line 679, in main
    converter(mooc_folder, args)
  File "scripts/converter.py", line 464, in converter
    data = parse_syllabus(syllabus_nb, content_folder)
  File "scripts/converter.py", line 77, in parse_syllabus
    syll = split_into_units(syllabus_file)[0]
  File "scripts/converter.py", line 145, in split_into_units
    with_output = cachedoutput.from_notebook_node(nb)[0]
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/nbconvert/exporters/notebook.py", line 26, in from_notebook_node
    nb_copy, resources = super(NotebookExporter, self).from_notebook_node(nb, resources, **kw)
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/nbconvert/exporters/exporter.py", line 124, in from_notebook_node
    resources = self._init_resources(resources)
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/nbconvert/exporters/exporter.py", line 275, in _init_resources
    resources['output_extension'] = self.file_extension
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/traitlets/traitlets.py", line 529, in __get__
    return self.get(obj, cls)
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/traitlets/traitlets.py", line 504, in get
    dynamic_default = self._dynamic_default_callable(obj)
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/traitlets/traitlets.py", line 484, in _dynamic_default_callable
    _deprecated_method(method, cls, meth_name, "use @default decorator instead.")
  File "/home/rskolasinski/miniconda3/envs/py35/lib/python3.5/site-packages/traitlets/traitlets.py", line 114, in _deprecated_method
    warn_explicit(warn_msg, DeprecationWarning, fname, lineno)
DeprecationWarning: NotebookExporter._file_extension_default is deprecated: use @default decorator instead.
```