### PR TITLE
allow arbitrary warning setting in converter, use 'ignore'

### DIFF
--- a/scripts/cachedoutput.py
+++ b/scripts/cachedoutput.py
@@ -15,7 +15,7 @@ import os
 import sys
 from textwrap import dedent
 
-from traitlets import Unicode, Integer, List, Bool
+from traitlets import Unicode, Integer, List
 from functools import lru_cache
 
 import nbformat

--- a/scripts/cachedoutput.py
+++ b/scripts/cachedoutput.py
@@ -95,10 +95,9 @@ class CachedOutputPreprocessor(ExecutePreprocessor):
     
     req_files = List(type=Unicode, config=True)   # prerequisite files - list of strings
     
-    # Set to True to treat warnings in code cells as errors. We do this to make the
-    # edx converter terminate if warnings are raised in code cells, as they
-    # spoil the output.
-    warnings_to_errors = Bool(False, config=True)
+    # Set to control the warnings filter. We do this to make the edx converter
+    # hide all warnings, as they spoil the output.
+    warnings = Unicode("default", config=True)
 
     def cache_key(self, source, cell_index):
         """Compute cache key for a cell
@@ -139,9 +138,10 @@ class CachedOutputPreprocessor(ExecutePreprocessor):
             self.log.debug("Cache hit[%i]: %s", cell_index, key)
             cell.outputs = [ nbformat.NotebookNode(output) for output in self.cache[key] ]
         else:
-            # Treat warnings as errors. Fix for the edx converter.
-            if self.warnings_to_errors:
-                self.kc.execute("import warnings; warnings.simplefilter('error')\n")
+            # Apply the warnings filter. Fix for the edx converter.
+            if self.warnings != "default":
+                self.kc.execute("import warnings; "
+                        "warnings.simplefilter('{}')".format(self.warnings))
             outputs = self.run_cell(cell, cell_index)
             # allow_errors inherited from ExecutePreprocessor: by default, is False.
             if not self.allow_errors:

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -51,7 +51,7 @@ cfg = Config({'NotebookExporter': {'preprocessors':
                                                          'code/edx_components.py',
                                                          'code/pfaffian.py',
                                                          'code/functions.py'],
-                                           'warnings_to_errors': True,
+                                           'warnings': 'ignore',
                                            'timeout': 300}})
 cachedoutput = NotebookExporter(cfg)
 


### PR DESCRIPTION
It was a bad idea to raise on every warning, especially since some of them are not happening on our side. This switches behavior to the opposite. @torosdahl makes sense?